### PR TITLE
Fix query string not formatting correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var request = require('request');
 var ee = require('events').EventEmitter;
 var util = require('util');
-var qs = require('querystring');
+var qs = require('query-string');
 var Omegle = function () {
 	ee.call(this);
 	this.useragent = 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "dumptyd",
   "license": "MIT",
   "dependencies": {
+    "query-string": "^6.12.1",
     "request": "^2.73.0"
   },
   "engines": {


### PR DESCRIPTION
Fixes the send() function not sending quotes and other special chars by changing the querystring package to an alternative package called query-string.